### PR TITLE
add user toggle for terminal colors

### DIFF
--- a/lua/wally/config.lua
+++ b/lua/wally/config.lua
@@ -19,6 +19,7 @@ config = {
     darkFloat = opt("dark_float", true),
     darkSidebar = opt("dark_sidebar", true),
     transparentSidebar = opt("transparent_sidebar", false),
+    terminalColors = opt("terminal_colors", false),
     sidebars = opt("sidebars", {}),
 }
 

--- a/lua/wally/util.lua
+++ b/lua/wally/util.lua
@@ -137,8 +137,13 @@ function util.load(theme)
     -- load base theme
     util.syntax(theme.base)
     util.syntax(theme.plugins)
-    util.terminal(theme.colors)
+
+    if theme.config.terminalColors then
+        util.terminal(theme.colors)
+    end
+
     util.autocmds(theme.config)
+
 end
 
 return util


### PR DESCRIPTION
Hi!

This just adds a bool toggle for the terminal colors set by wally. With my current wal colorcscheme, the terminal colors in vim didn't look very nice but my regular terminal colors looked fine.

to set:
```
vim.g.wally_terminal_colors = false|true
```